### PR TITLE
@example tag examples will be shown with a header and formatted code samples

### DIFF
--- a/template/index.jade
+++ b/template/index.jade
@@ -112,8 +112,8 @@ html(lang='en-us')
                  -break;
             each tag in symbol.tags
               if tag.type == 'example'
-                 pre
-                    code.language-javascript !{tag.html}
+                pre
+                  code.language-javascript !{tag.string}
                     
           .footer.site-footer
             .span.site-footer-owner

--- a/template/index.jade
+++ b/template/index.jade
@@ -106,6 +106,15 @@ html(lang='en-us')
               h5 JSFiddle
               p
                 iframe(width="100%", height="300", src=symbol.jsfiddle , allowfullscreen="allowfullscreen", frameborder="0")
+            each tag in symbol.tags
+              if tag.type == 'example'
+                 h3 Examples
+                 -break;
+            each tag in symbol.tags
+              if tag.type == 'example'
+                 pre
+                    code.language-javascript !{tag.html}
+                    
           .footer.site-footer
             .span.site-footer-owner
               a(href='https://github.com/mr-doc/mr-doc-theme-cayman') Cayman


### PR DESCRIPTION
Original issue mr-doc/mr-doc#105

This supports multiple example tags as well.
I'm new to Jade so please let me know if there's a better way!
